### PR TITLE
Wire vault password support into the ansible-pull bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ On a fresh machine with no Ansible installed:
 curl -fsSL https://raw.githubusercontent.com/Japenner/ansible/main/ansible-run | bash
 ```
 
-This installs Ansible via the official PPA, then runs `ansible-pull` to clone the repo and execute `ubuntu.yml`.
-
-> **Known gap:** this one-liner doesn't pass a vault password, so it currently fails on the `ssh` role's vault-encrypted key copy ([#13](https://github.com/Japenner/ansible/issues/13)). Until that's fixed, clone the repo and use `make run` below instead, which prompts for the vault password interactively.
+This installs Ansible via the official PPA, then runs `ansible-pull --ask-vault-pass` to clone the repo and execute `ubuntu.yml`. You'll be prompted for the vault password before any role runs — the `ssh` role's vault-encrypted key copy needs it to succeed.
 
 ### Run locally
 
@@ -107,7 +105,6 @@ docker run --rm -e TAGS="--ask-vault-pass" -it new-computer
 
 - **Non-amd64 hosts aren't fully supported yet.** `mise` and `repo_packages` hardcode `arch=amd64` in their apt source lines (unlike `docker`'s role, which derives the arch correctly), so package installs there fail on arm64 ([#16](https://github.com/Japenner/ansible/issues/16)).
 - **The `signal-desktop` repo entry has the wrong apt suite** (`stable` instead of `xenial`), so it currently fails with "does not have a Release file" ([#15](https://github.com/Japenner/ansible/issues/15)).
-- **The one-line curl bootstrap doesn't handle the vault password** — see the note under [Bootstrap from scratch](#bootstrap-from-scratch) ([#13](https://github.com/Japenner/ansible/issues/13)).
 
 See the [open issues](https://github.com/Japenner/ansible/issues) for the full cleanup/modernization backlog.
 

--- a/ansible-run
+++ b/ansible-run
@@ -6,4 +6,4 @@ sudo apt-get update -y
 sudo apt-get install -y curl git software-properties-common ansible
 
 ## pull ansible
-sudo ansible-pull -U https://github.com/Japenner/ansible ubuntu.yml
+sudo ansible-pull -U https://github.com/Japenner/ansible --ask-vault-pass ubuntu.yml


### PR DESCRIPTION
## Overview

This pull request wires a vault password prompt into the `ansible-run` curl|bash bootstrap so the `ssh` role's vault-encrypted key copy can actually succeed unattended.

## Why

The one-line bootstrap stalled on the first vault-encrypted task since `ansible-pull` had no way to supply a vault password. That defeats the point of a one-command provision.

## Ticket(s)

- Closes #13

## Details

**Vault password flag on the pull invocation:**

- Added `--ask-vault-pass` to the `ansible-pull` call in `ansible-run`. Ansible prompts for the vault password before any role runs, so this gates the whole playbook upfront rather than failing partway through on the `ssh` role.

**README updates:**

- Removed the "Known gap" callout under Bootstrap from scratch and replaced it with a note that the one-liner now prompts for the vault password.
- Removed the corresponding entry from Known Limitations, since the gap is closed.

## How to Test

- `make check` and `make lint` both pass.
- Run `curl -fsSL .../ansible-run | bash` (or inspect the script) and confirm it prompts for the vault password before `ansible-pull` starts cloning/running the playbook.
- Note: a full end-to-end run against a real vault password wasn't exercised here since that requires the actual vault secret and a disposable machine — the flag itself is identical to the one `make run` already uses successfully (`ansible-playbook --ask-vault-pass`), so the same decrypt-then-continue behavior applies.