### PR TITLE
Fix CI push trigger pointing at nonexistent master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Overview

This pull request fixes `.github/workflows/ci.yml`'s push trigger, which pointed at a `master` branch that doesn't exist in this repo.

## Why

CI silently never ran on direct pushes to `main` since the push trigger was still watching `master` — only the untargeted `pull_request` trigger was actually firing.

## Ticket(s)

- Closes #14

## Details

**CI push trigger:**

- Changed `on.push.branches` from `[master]` to `[main]` in `.github/workflows/ci.yml`.

**README bootstrap URL:**

- No change needed — `README.md`'s curl command already points at `main`, contrary to what the issue described. Confirmed via `grep`.

## How to Test

- `git ls-remote --heads origin master` returns nothing; `main` is the only/default branch.
- After this PR merges, a direct push to `main` should trigger the `CI` workflow (previously it wouldn't have).