### PR TITLE
Fix signal-desktop apt suite — stable doesn't exist, xenial does

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -100,7 +100,7 @@ repo_packages:
     gpg_key_url: "https://updates.signal.org/desktop/apt/keys.asc"
     armored: true
     repo: "https://updates.signal.org/desktop/apt"
-    build: stable
+    build: xenial
     branch: main
   - name: brave-browser
     gpg_key_url: "https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg"


### PR DESCRIPTION
## Overview

This pull request fixes the `signal-desktop` apt repo entry in `group_vars/all.yml`, changing `build: stable` to `build: xenial`.

## Why

Signal's apt repo has never published a `stable` suite — it only publishes `xenial`, kept as a fixed codename regardless of actual Ubuntu version. `repo_packages` was breaking on this entry every time.

## Ticket(s)

- Closes #15

## Details

**Fixed apt suite value:**

- Changed `signal-desktop.build` from `stable` to `xenial` in `group_vars/all.yml` — verified live that `dists/stable/Release` 404s and `dists/xenial/Release` resolves.

## How to Test

- `make check && make lint` — both pass
- Ran `ansible-playbook --tags repo ubuntu.yml` inside an amd64 Docker container built from this repo's `Dockerfile`; `signal-desktop` installed cleanly (`dpkg -l` confirms `ii signal-desktop 8.18.0 amd64`)
- Other `repo_packages` entries (slack, code) installed cleanly in the same run; `brave-browser`'s unrelated dependency conflict is pre-existing and out of scope