### PR TITLE
Stop hardcoding amd64 in mise, repo_packages, and Lazydocker

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -60,10 +60,22 @@
         groups: docker
         append: true
 
+- name: Determine dpkg architecture
+  become: true
+  ansible.builtin.command:
+    cmd: dpkg --print-architecture
+  register: dpkg_arch
+  changed_when: false
+  tags: lazydocker
+
 - name: Download Lazydocker
   become: true
+  vars:
+    lazydocker_arch_map:
+      amd64: x86_64
+      arm64: arm64
   ansible.builtin.get_url:
-    url: "https://github.com/jesseduffield/lazydocker/releases/download/v0.23.3/lazydocker_0.23.3_Linux_x86_64.tar.gz"
+    url: "https://github.com/jesseduffield/lazydocker/releases/download/v0.23.3/lazydocker_0.23.3_Linux_{{ lazydocker_arch_map[dpkg_arch.stdout] }}.tar.gz"
     dest: /tmp/lazydocker.tar.gz
     mode: "0644"
   register: lazydocker_download

--- a/roles/mise/tasks/main.yml
+++ b/roles/mise/tasks/main.yml
@@ -22,9 +22,15 @@
         cmd: gpg --dearmor -o /etc/apt/keyrings/mise-archive-keyring.gpg /tmp/mise-key.asc
         creates: /etc/apt/keyrings/mise-archive-keyring.gpg
 
+    - name: Determine dpkg architecture
+      ansible.builtin.command:
+        cmd: dpkg --print-architecture
+      register: dpkg_arch
+      changed_when: false
+
     - name: Add mise apt repository
       ansible.builtin.apt_repository:
-        repo: "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=amd64] https://mise.jdx.dev/deb stable main"
+        repo: "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch={{ dpkg_arch.stdout }}] https://mise.jdx.dev/deb stable main"
         filename: mise
         state: present
         update_cache: true

--- a/roles/repo_packages/tasks/install.yml
+++ b/roles/repo_packages/tasks/install.yml
@@ -29,7 +29,7 @@
 
     - name: "Add repository: {{ item.name }}"
       ansible.builtin.apt_repository:
-        repo: "deb [arch=amd64 signed-by={{ keyring_path }}] {{ item.repo }} {{ item.build }} {{ item.branch }}"
+        repo: "deb [arch={{ dpkg_arch.stdout }} signed-by={{ keyring_path }}] {{ item.repo }} {{ item.build }} {{ item.branch }}"
         state: present
         update_cache: true
 

--- a/roles/repo_packages/tasks/main.yml
+++ b/roles/repo_packages/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Determine dpkg architecture
+  become: true
+  ansible.builtin.command:
+    cmd: dpkg --print-architecture
+  register: dpkg_arch
+  changed_when: false
+  tags: repo
+
 - name: Install each repository-only package
   ansible.builtin.include_tasks: install.yml
   loop: "{{ repo_packages }}"


### PR DESCRIPTION
## Overview

This pull request derives apt/download architecture from `dpkg --print-architecture` in the `mise` and `repo_packages` roles, and maps it to the matching release asset name for Lazydocker's download in the `docker` role, instead of hardcoding `amd64`/`x86_64`.

## Why

These three spots hardcoded amd64, unlike the `docker` role's own apt source line, which already derives arch correctly. Any non-amd64 host silently failed installing packages gated behind these roles.

## Ticket(s)

- Closes #16

## Details

**Arch detection:**

- `mise`, `repo_packages`, and `docker` (for Lazydocker) each now run `dpkg --print-architecture` and register the result before building their apt source line or download URL.
- Lazydocker's download maps the dpkg arch (`amd64`/`arm64`) to the release asset naming Lazydocker actually publishes (`x86_64`/`arm64`) via a small vars map.

## How to Test

Built the repo's Docker test images and ran the affected roles directly:

- `--tags mise,repo,lazydocker` on the default (arm64) image — mise, slack, signal-desktop, brave-browser, code, and Lazydocker all installed with the correctly derived `arch=arm64` / `Linux_arm64` asset.
- Same tags rebuilt with `docker build --platform linux/amd64` — same roles installed with `arch=amd64` / `Linux_x86_64` correctly derived.
- One `mise use --global ruby@latest` failure appeared on both arches (a pre-existing `ruby-build` compile issue, unrelated to arch derivation) and one `brave-browser` install hit an unrelated `liboss4-salsa-asound2`/`libasound2` conflict in the amd64 test image — neither is caused by this change.

This covers AC4 (verify on both amd64 and arm64) via the two Docker builds above rather than a physical arm64 host.