### PR TITLE
Migrate apt_repository to deb822_repository in mise and repo_packages

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -24,6 +24,7 @@ apt_packages:
     - ccache
     - ninja-build
     - python3-pip
+    - python3-debian
     - dconf-editor
     - moreutils
     - clangd
@@ -92,25 +93,21 @@ deb_packages:
 repo_packages:
   - name: slack
     gpg_key_url: "https://packagecloud.io/slacktechnologies/slack/gpgkey"
-    armored: true
-    repo: "https://packagecloud.io/slacktechnologies/slack/debian/"
-    build: jessie
-    branch: main
+    uris: "https://packagecloud.io/slacktechnologies/slack/debian/"
+    suites: jessie
+    components: main
   - name: signal-desktop
     gpg_key_url: "https://updates.signal.org/desktop/apt/keys.asc"
-    armored: true
-    repo: "https://updates.signal.org/desktop/apt"
-    build: xenial
-    branch: main
+    uris: "https://updates.signal.org/desktop/apt"
+    suites: xenial
+    components: main
   - name: brave-browser
     gpg_key_url: "https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg"
-    armored: false
-    repo: "https://brave-browser-apt-release.s3.brave.com/"
-    build: stable
-    branch: main
+    uris: "https://brave-browser-apt-release.s3.brave.com/"
+    suites: stable
+    components: main
   - name: code
     gpg_key_url: "https://packages.microsoft.com/keys/microsoft.asc"
-    armored: true
-    repo: "https://packages.microsoft.com/repos/code"
-    build: stable
-    branch: main
+    uris: "https://packages.microsoft.com/repos/code"
+    suites: stable
+    components: main

--- a/roles/mise/tasks/main.yml
+++ b/roles/mise/tasks/main.yml
@@ -5,23 +5,6 @@
     - asdf
     - mise
   block:
-    - name: Ensure apt keyrings directory exists
-      ansible.builtin.file:
-        path: /etc/apt/keyrings
-        state: directory
-        mode: "0755"
-
-    - name: Download mise GPG key
-      ansible.builtin.get_url:
-        url: https://mise.jdx.dev/gpg-key.pub
-        dest: /tmp/mise-key.asc
-        mode: "0644"
-
-    - name: Dearmor mise GPG key
-      ansible.builtin.command:
-        cmd: gpg --dearmor -o /etc/apt/keyrings/mise-archive-keyring.gpg /tmp/mise-key.asc
-        creates: /etc/apt/keyrings/mise-archive-keyring.gpg
-
     - name: Determine dpkg architecture
       ansible.builtin.command:
         cmd: dpkg --print-architecture
@@ -29,16 +12,20 @@
       changed_when: false
 
     - name: Add mise apt repository
-      ansible.builtin.apt_repository:
-        repo: "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch={{ dpkg_arch.stdout }}] https://mise.jdx.dev/deb stable main"
-        filename: mise
-        state: present
-        update_cache: true
+      ansible.builtin.deb822_repository:
+        name: mise
+        types: deb
+        uris: https://mise.jdx.dev/deb
+        suites: stable
+        components: main
+        architectures: "{{ dpkg_arch.stdout }}"
+        signed_by: https://mise.jdx.dev/gpg-key.pub
 
     - name: Install mise
       ansible.builtin.apt:
         name: mise
         state: present
+        update_cache: true
 
 - name: Install and set global language versions with mise
   become: true

--- a/roles/repo_packages/tasks/install.yml
+++ b/roles/repo_packages/tasks/install.yml
@@ -1,39 +1,20 @@
 ---
 - name: "Add repository and install: {{ item.name }}"
   become: true
-  vars:
-    keyring_path: "/usr/share/keyrings/{{ item.name }}-archive-keyring.gpg"
-    armored_tmp: "/tmp/{{ item.name }}-key.asc"
   tags: repo
   block:
-    - name: "Download GPG key (binary): {{ item.name }}"
-      ansible.builtin.get_url:
-        url: "{{ item.gpg_key_url }}"
-        dest: "{{ keyring_path }}"
-        mode: "0644"
-      when: not item.armored
-
-    # ASCII-armored keys (Slack, Signal) must be dearmored or apt rejects them.
-    - name: "Download armored GPG key: {{ item.name }}"
-      ansible.builtin.get_url:
-        url: "{{ item.gpg_key_url }}"
-        dest: "{{ armored_tmp }}"
-        mode: "0644"
-      when: item.armored
-
-    - name: "Dearmor GPG key: {{ item.name }}"
-      ansible.builtin.command:
-        cmd: "gpg --dearmor -o {{ keyring_path }} {{ armored_tmp }}"
-        creates: "{{ keyring_path }}"
-      when: item.armored
-
     - name: "Add repository: {{ item.name }}"
-      ansible.builtin.apt_repository:
-        repo: "deb [arch={{ dpkg_arch.stdout }} signed-by={{ keyring_path }}] {{ item.repo }} {{ item.build }} {{ item.branch }}"
-        state: present
-        update_cache: true
+      ansible.builtin.deb822_repository:
+        name: "{{ item.name }}"
+        types: deb
+        uris: "{{ item.uris }}"
+        suites: "{{ item.suites }}"
+        components: "{{ item.components }}"
+        architectures: "{{ dpkg_arch.stdout }}"
+        signed_by: "{{ item.gpg_key_url }}"
 
     - name: "Install package: {{ item.name }}"
       ansible.builtin.apt:
         name: "{{ item.name }}"
         state: present
+        update_cache: true


### PR DESCRIPTION
## Overview

This pull request migrates the `mise` and `repo_packages` roles off the deprecated `ansible.builtin.apt_repository` module and onto `ansible.builtin.deb822_repository`.

## Why

`apt_repository` throws a deprecation warning on every run and gets removed in ansible-core 2.25. Doing this on our own schedule beats provisioning breaking outright once that ships.

## Ticket(s)

- Closes #17

## Details

**mise role:**

- `deb822_repository`'s `signed_by` accepts a GPG key URL directly, so the manual `get_url` + `gpg --dearmor` + keyrings-directory dance is gone. The role just points `signed_by` at `https://mise.jdx.dev/gpg-key.pub`.

**repo_packages role:**

- Same simplification applies to all four repo_packages entries (slack, signal-desktop, brave-browser, code): dropped the binary/armored branching and keyring-path plumbing entirely.
- `group_vars/all.yml`'s `repo_packages` schema changed field names to match `deb822_repository`'s parameters: `repo` -> `uris`, `build` -> `suites`, `branch` -> `components`. The `armored` field is gone since `signed_by` handles both armored and binary keys transparently.

**New dependency:**

- `deb822_repository` requires `python3-debian`, which wasn't previously installed. Added it to `apt_packages.core` in `group_vars/all.yml` — it installs early via the `core` role, ahead of `mise` and `repo_packages` in `ubuntu.yml`'s role order.

## Known gaps

- `brave-browser`'s install failed in testing on a pinned-version dependency conflict (`liboss4-salsa-asound2` vs `libasound2`) unrelated to this migration — it's the stale-pinned-version issue already tracked in #21.
- The arch-hardcoding bug in these same two roles (#16) is explicitly out of scope per the issue and untouched here.

## How to Test

- `make check && make lint` — both pass, no `apt_repository` deprecation warning.
- `make docker` then `docker run --rm new-computer bash -lc "sudo ansible-playbook --tags core,mise,repo ubuntu.yml"` — confirms `mise`, `slack`, and `signal-desktop` install end-to-end; `brave-browser`'s repo add succeeds (its install failure is the pre-existing #21 issue); `code` verified separately and installs cleanly.