### PR TITLE
Add requirements.yml for the ansible.posix collection dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install tooling
         run: pip install ansible ansible-lint yamllint
 
+      - name: Install collections
+        run: ansible-galaxy collection install -r requirements.yml
+
       - name: yamllint
         run: yamllint .
 

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,11 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 	  awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-9s\033[0m %s\n", $$1, $$2}'
 
-install: ## Install Ansible via the official PPA (Ubuntu)
+install: ## Install Ansible via the official PPA (Ubuntu) and required collections
 	sudo apt-add-repository -y ppa:ansible/ansible
 	sudo apt-get update -y
 	sudo apt-get install -y ansible
+	ansible-galaxy collection install -r requirements.yml
 
 run: ## Provision this machine (prompts for vault + sudo passwords)
 	ansible-playbook --ask-vault-pass --ask-become-pass $(PLAYBOOK)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Running the playbook on a bare Ubuntu machine installs and configures everything
 - `make` and `git`
 - SSH private key committed (vault-encrypted) at `.ssh/id_ed25519`, copied to `~/.ssh/` by the playbook
 - The Ansible vault password — needed to decrypt the SSH key at provision time
-- The `ansible.posix` collection (for `authorized_key`). Installing `ansible` via `make install`'s PPA pulls in the full community bundle, which includes it; a bare `ansible-core` install won't have it
+- The `ansible.posix` collection (for `authorized_key`), declared in `requirements.yml` and installed by `make install` via `ansible-galaxy collection install -r requirements.yml`
 
 > `auth_codes/` holds additional vault-encrypted secrets (API keys, tokens). They are an encrypted store kept alongside the repo; the playbook itself does not consume them.
 
@@ -34,7 +34,7 @@ This installs Ansible via the official PPA, then runs `ansible-pull --ask-vault-
 With the repo cloned:
 
 ```bash
-make install   # install Ansible via the official PPA (Ubuntu)
+make install   # install Ansible via the official PPA (Ubuntu) and required collections
 make run       # provision this machine
 ```
 
@@ -44,7 +44,7 @@ Run `make` (or `make help`) to list all targets:
 
 | Target | What it does |
 | --- | --- |
-| `make install` | Install Ansible via the official PPA |
+| `make install` | Install Ansible via the official PPA and collections from `requirements.yml` |
 | `make run` | Provision this machine (prompts for vault + sudo passwords) |
 | `make check` | Syntax-check the playbook |
 | `make lint` | Run `ansible-lint` and `yamllint` |

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: ansible.posix


### PR DESCRIPTION
## Overview

This pull request adds a `requirements.yml` at the repo root declaring the `ansible.posix` collection dependency and wires its install into `make install` and CI.

## Why

`roles/ssh/tasks/main.yml` uses `ansible.posix.authorized_key`, but nothing in the repo declared that dependency. A bare `ansible-core` install (rather than the full community bundle) doesn't pull it in, so the ssh role fails with an unhelpful missing-module error.

## Ticket(s)

- Closes #18

## Details

**Collection manifest:**

- Added `requirements.yml` declaring `ansible.posix`, confirmed via `git grep` that it's the only non-builtin module in use (`community.general` was previously removed and isn't reintroduced).

**Wired install into make and CI:**

- `make install` now runs `ansible-galaxy collection install -r requirements.yml` after installing Ansible.
- CI (`.github/workflows/ci.yml`) installs collections from `requirements.yml` before `ansible-lint` and the syntax check.
- Updated the README's prerequisites and provisioning sections to reflect the new install step.

## How to Test

1. `ansible-galaxy collection install -r requirements.yml` resolves cleanly.
2. `make check` and `make lint` pass.
3. CI run is green.