### PR TITLE
Pin ansible, ansible-lint, and yamllint versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tooling
-        run: pip install ansible ansible-lint yamllint
+        run: pip install -r requirements-dev.txt
 
       - name: Install collections
         run: ansible-galaxy collection install -r requirements.yml

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ make check   # syntax check (no extra tooling needed)
 make lint    # ansible-lint + yamllint (must be installed)
 ```
 
+### Tooling versions
+
+CI installs `ansible`, `ansible-lint`, and `yamllint` from `requirements-dev.txt`, which pins each to an exact version (currently `ansible-core` 2.18.x, via `ansible==11.9.0`). This is deliberate: unpinned tooling can change lint/CI behavior on any run with no corresponding code change, making failures hard to bisect.
+
+`make install` pulls Ansible from `ppa:ansible/ansible` (Ubuntu's PPA, not pip) and doesn't pin an exact version — it should stay within the same `ansible-core` 2.18.x range as `requirements-dev.txt` so local and CI runs don't drift apart. If the PPA's current release moves to a different major/minor, bump `requirements-dev.txt` to match rather than letting the two diverge silently.
+
+To bump these pins deliberately: update the versions in `requirements-dev.txt` in their own commit, run `make check` and `make lint` locally against the new versions, and update the `ansible-core` range noted above if it changed.
+
 A Docker image lets you exercise the playbook without a real machine:
 
 ```bash

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+# Tooling versions used by CI and `make install`/`make lint`.
+# Pinned exactly (not a range) so lint/CI behavior only changes when this
+# file changes — bump deliberately, in its own commit, after confirming
+# `make check` and `make lint` still pass with the new versions.
+ansible==11.9.0
+ansible-lint==25.11.0
+yamllint==1.37.1


### PR DESCRIPTION
## Overview

This pull request pins `ansible`, `ansible-lint`, and `yamllint` to exact versions in a new `requirements-dev.txt`, and points CI at it instead of always resolving to latest.

## Why

Unpinned tooling means lint/CI behavior can change on any run with zero corresponding code change. We already hit this once when `apt_repository`'s deprecation warning showed up unannounced because `ansible-core` moved out from under the repo.

## Ticket(s)

- Closes #19

## Details

**Pinned dev tooling:**

- Added `requirements-dev.txt` pinning `ansible==11.9.0` (ansible-core 2.18.18), `ansible-lint==25.11.0`, and `yamllint==1.37.1`. Verified the pins resolve cleanly together in a clean venv.
- CI's "Install tooling" step now runs `pip install -r requirements-dev.txt` instead of an unpinned `pip install ansible ansible-lint yamllint`.

**Docs:**

- README now documents the target `ansible-core` 2.18.x range for `make install` (which still installs from the `ppa:ansible/ansible` PPA, unpinned, per the issue's stated out-of-scope) and the bump process: update `requirements-dev.txt` in its own commit, run `make check` and `make lint` against the new versions, adjust the documented range if it moved.

## How to Test

```bash
make check
make lint
```

Both pass locally. CI will confirm the pinned install works in a clean runner.