### PR TITLE
Add a CI job that actually runs the playbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,11 @@ jobs:
       # github.com, neither of which this repo hands to CI. `docker` is also
       # excluded: installing the apt package is fine, but starting the
       # dockerd service via sysvinit needs a privileged container, which
-      # this job doesn't run with (see #33).
+      # this job doesn't run with (see #33). `deb_packages` (`install`) and
+      # `repo_packages` (`repo`) are excluded too: several pinned versions
+      # (rustdesk, brave-browser) hit real dependency conflicts on Ubuntu
+      # 24.04, tracked separately by #34 rather than fixed here.
       - name: Run playbook inside container
         run: >
           docker run --rm new-computer
-          ansible-playbook --tags core,fonts,zsh,mise,deb_packages,repo_packages ubuntu.yml
+          ansible-playbook --tags core,font,zsh,mise ubuntu.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,20 @@ jobs:
 
       - name: Syntax check
         run: ansible-playbook --syntax-check ubuntu.yml
+
+  provision:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build test image
+        run: docker build -t new-computer .
+
+      # Only tags that need no vault password and no SSH access are safe to
+      # run in CI. `ssh`, `dotfiles`, and `personal_projects` all require a
+      # decrypted deploy key (vault) and/or `git clone` over SSH to
+      # github.com, neither of which this repo hands to CI.
+      - name: Run playbook inside container
+        run: >
+          docker run --rm new-computer
+          ansible-playbook --tags core,fonts,docker,zsh,mise,deb_packages,repo_packages ubuntu.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,11 @@ jobs:
       # Only tags that need no vault password and no SSH access are safe to
       # run in CI. `ssh`, `dotfiles`, and `personal_projects` all require a
       # decrypted deploy key (vault) and/or `git clone` over SSH to
-      # github.com, neither of which this repo hands to CI.
+      # github.com, neither of which this repo hands to CI. `docker` is also
+      # excluded: installing the apt package is fine, but starting the
+      # dockerd service via sysvinit needs a privileged container, which
+      # this job doesn't run with (see #33).
       - name: Run playbook inside container
         run: >
           docker run --rm new-computer
-          ansible-playbook --tags core,fonts,docker,zsh,mise,deb_packages,repo_packages ubuntu.yml
+          ansible-playbook --tags core,fonts,zsh,mise,deb_packages,repo_packages ubuntu.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TAGS=""
 
 RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y software-properties-common sudo curl git build-essential && \
+    apt-get install -y software-properties-common sudo curl git build-essential unzip fontconfig && \
     apt-add-repository -y ppa:ansible/ansible && \
     apt-get update && apt-get install -y ansible && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Available tags: `ssh`, `font`, `core`, `productivity`, `docker`, `lazydocker`, `
 
 ## Development / Testing
 
-`ansible-lint`, `yamllint`, and a `--syntax-check` run on every push and pull request via GitHub Actions (`.github/workflows/ci.yml`). Run the same checks locally:
+`ansible-lint`, `yamllint`, and a `--syntax-check` run on every push and pull request via GitHub Actions (`.github/workflows/ci.yml`). A second job builds the `new-computer` test image and actually runs the playbook inside it, scoped to `--tags core,fonts,docker,zsh,mise,deb_packages,repo_packages` — the subset that needs neither a vault password nor SSH access. `ssh`, `dotfiles`, and `personal_projects` are excluded from CI for that reason and are only exercised locally. Run the same checks locally:
 
 ```bash
 make check   # syntax check (no extra tooling needed)
@@ -158,7 +158,7 @@ Purges packages, removes configs, and cleans up APT sources.
 
 ## Contributing
 
-Branch off `main`. GitHub Actions runs `yamllint`, `ansible-lint`, and `ansible-playbook --syntax-check` on every push and pull request — run `make lint` and `make check` locally before opening a PR. If your change touches a role's tasks, exercise it for real with `make test` (or `docker run --rm new-computer ansible-playbook --tags <role> ubuntu.yml` for a scoped run) rather than relying on syntax-check alone; CI doesn't currently run the playbook itself ([#20](https://github.com/Japenner/ansible/issues/20)).
+Branch off `main`. GitHub Actions runs `yamllint`, `ansible-lint`, `ansible-playbook --syntax-check`, and a real containerized run of the playbook (scoped to the vault/SSH-free tags listed above) on every push and pull request — run `make lint` and `make check` locally before opening a PR. If your change touches a role outside that safe tag set (`ssh`, `dotfiles`, `personal_projects`), exercise it locally with `docker run --rm -e TAGS="--ask-vault-pass --tags <role>" -it new-computer` since CI can't run it.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Available tags: `ssh`, `font`, `core`, `productivity`, `docker`, `lazydocker`, `
 
 ## Development / Testing
 
-`ansible-lint`, `yamllint`, and a `--syntax-check` run on every push and pull request via GitHub Actions (`.github/workflows/ci.yml`). A second job builds the `new-computer` test image and actually runs the playbook inside it, scoped to `--tags core,fonts,zsh,mise,deb_packages,repo_packages` — the subset that needs neither a vault password nor SSH access. `ssh`, `dotfiles`, and `personal_projects` are excluded from CI for that reason and are only exercised locally; `docker` is also excluded because starting the dockerd service needs a privileged container ([#33](https://github.com/Japenner/ansible/issues/33)). Run the same checks locally:
+`ansible-lint`, `yamllint`, and a `--syntax-check` run on every push and pull request via GitHub Actions (`.github/workflows/ci.yml`). A second job builds the `new-computer` test image and actually runs the playbook inside it, scoped to `--tags core,font,zsh,mise` — the subset that needs neither a vault password nor SSH access. `ssh`, `dotfiles`, and `personal_projects` are excluded from CI for that reason and are only exercised locally; `docker` is also excluded because starting the dockerd service needs a privileged container ([#33](https://github.com/Japenner/ansible/issues/33)); `deb_packages` and `repo_packages` are excluded because several pinned versions (rustdesk, brave-browser) hit real dependency conflicts on Ubuntu 24.04, tracked by [#34](https://github.com/Japenner/ansible/issues/34) rather than this job. Run the same checks locally:
 
 ```bash
 make check   # syntax check (no extra tooling needed)
@@ -158,7 +158,7 @@ Purges packages, removes configs, and cleans up APT sources.
 
 ## Contributing
 
-Branch off `main`. GitHub Actions runs `yamllint`, `ansible-lint`, `ansible-playbook --syntax-check`, and a real containerized run of the playbook (scoped to the safe tags listed above) on every push and pull request — run `make lint` and `make check` locally before opening a PR. If your change touches a role outside that safe tag set (`ssh`, `dotfiles`, `personal_projects`, `docker`), exercise it locally with `docker run --rm -e TAGS="--ask-vault-pass --tags <role>" -it new-computer` since CI can't run it.
+Branch off `main`. GitHub Actions runs `yamllint`, `ansible-lint`, `ansible-playbook --syntax-check`, and a real containerized run of the playbook (scoped to the safe tags listed above) on every push and pull request — run `make lint` and `make check` locally before opening a PR. If your change touches a role outside that safe tag set (`ssh`, `dotfiles`, `personal_projects`, `docker`, `deb_packages`, `repo_packages`), exercise it locally with `docker run --rm -e TAGS="--ask-vault-pass --tags <role>" -it new-computer` since CI can't run it.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Available tags: `ssh`, `font`, `core`, `productivity`, `docker`, `lazydocker`, `
 
 ## Development / Testing
 
-`ansible-lint`, `yamllint`, and a `--syntax-check` run on every push and pull request via GitHub Actions (`.github/workflows/ci.yml`). A second job builds the `new-computer` test image and actually runs the playbook inside it, scoped to `--tags core,fonts,docker,zsh,mise,deb_packages,repo_packages` — the subset that needs neither a vault password nor SSH access. `ssh`, `dotfiles`, and `personal_projects` are excluded from CI for that reason and are only exercised locally. Run the same checks locally:
+`ansible-lint`, `yamllint`, and a `--syntax-check` run on every push and pull request via GitHub Actions (`.github/workflows/ci.yml`). A second job builds the `new-computer` test image and actually runs the playbook inside it, scoped to `--tags core,fonts,zsh,mise,deb_packages,repo_packages` — the subset that needs neither a vault password nor SSH access. `ssh`, `dotfiles`, and `personal_projects` are excluded from CI for that reason and are only exercised locally; `docker` is also excluded because starting the dockerd service needs a privileged container ([#33](https://github.com/Japenner/ansible/issues/33)). Run the same checks locally:
 
 ```bash
 make check   # syntax check (no extra tooling needed)
@@ -158,7 +158,7 @@ Purges packages, removes configs, and cleans up APT sources.
 
 ## Contributing
 
-Branch off `main`. GitHub Actions runs `yamllint`, `ansible-lint`, `ansible-playbook --syntax-check`, and a real containerized run of the playbook (scoped to the vault/SSH-free tags listed above) on every push and pull request — run `make lint` and `make check` locally before opening a PR. If your change touches a role outside that safe tag set (`ssh`, `dotfiles`, `personal_projects`), exercise it locally with `docker run --rm -e TAGS="--ask-vault-pass --tags <role>" -it new-computer` since CI can't run it.
+Branch off `main`. GitHub Actions runs `yamllint`, `ansible-lint`, `ansible-playbook --syntax-check`, and a real containerized run of the playbook (scoped to the safe tags listed above) on every push and pull request — run `make lint` and `make check` locally before opening a PR. If your change touches a role outside that safe tag set (`ssh`, `dotfiles`, `personal_projects`, `docker`), exercise it locally with `docker run --rm -e TAGS="--ask-vault-pass --tags <role>" -it new-computer` since CI can't run it.
 
 ## License
 

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -29,12 +29,12 @@
 
     - name: Dearmor Docker GPG key
       ansible.builtin.command:
-        cmd: gpg --dearmor -o /etc/apt/keyrings/docker.asc /tmp/docker-key.asc
-        creates: /etc/apt/keyrings/docker.asc
+        cmd: gpg --dearmor -o /etc/apt/keyrings/docker.gpg /tmp/docker-key.asc
+        creates: /etc/apt/keyrings/docker.gpg
 
     - name: Add Docker APT source list
       ansible.builtin.shell: |
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
       args:
         creates: /etc/apt/sources.list.d/docker.list
 

--- a/roles/mise/tasks/main.yml
+++ b/roles/mise/tasks/main.yml
@@ -27,6 +27,16 @@
         state: present
         update_cache: true
 
+- name: Use precompiled Ruby binaries instead of building from source
+  become: true
+  become_user: "{{ user }}"
+  ansible.builtin.command:
+    cmd: mise settings ruby.compile=false
+  changed_when: true
+  tags:
+    - asdf
+    - mise
+
 - name: Install and set global language versions with mise
   become: true
   become_user: "{{ user }}"


### PR DESCRIPTION
## Overview

This pull request adds a `provision` job to CI that builds the `new-computer` test image and runs `ubuntu.yml` inside it, instead of relying on `--syntax-check` alone.

## Why

Two real bugs (the `signal-desktop` apt suite and the hardcoded `arch=amd64` values) both passed lint and syntax-check cleanly and only surfaced when the playbook was actually run. The Docker test harness for this already existed and just wasn't wired into CI.

## Ticket(s)

- Closes #20

## Details

**New `provision` job:**

- Builds `new-computer` from the repo's `Dockerfile`.
- Runs `ansible-playbook --tags core,font,zsh,mise ubuntu.yml` inside it — the roles that need neither a vault password nor SSH access and pass clean on Ubuntu 24.04 today.
- `ssh`, `dotfiles`, and `personal_projects` stay out of CI because they need vault/SSH access. `docker` is out because starting the dockerd service via sysvinit needs a privileged container (#33). `deb_packages` and `repo_packages` are out because running them for real surfaced genuine Ubuntu 24.04 dependency conflicts in the package pins themselves (#34) — separate from the CI wiring this PR is about.
- Task failures now fail the build, since this is a real playbook run and not just a syntax check.

**Bugs actually running the playbook turned up and fixed here:**

- `roles/docker/tasks/main.yml`: the dearmored Docker GPG key was named `docker.asc`. `apt-key`'s `dearmor_filename()` helper treats any `*.asc` file as still-armored and re-processes it, corrupting an already-binary keyring and producing `NO_PUBKEY` on `apt-get update`. Renamed to `docker.gpg`, matching Docker's own documented convention.
- `roles/mise/tasks/main.yml`: `ruby@latest` was compiling from source and failing on missing native build deps. Added `mise settings ruby.compile=false` so it fetches a precompiled binary instead.
- `Dockerfile`: added `unzip` and `fontconfig` — the `fonts` role needs both to unzip and register the Nerd Font, and the test image never had them since only `--syntax-check` ran before.

**README:**

- Updated the Development/Testing and Contributing sections to describe the new job, the final safe tag set, and where to look for each exclusion's tracking issue.

## Known Gaps

- #33 — running `docker` in CI needs a privileged container to actually start the dockerd service.
- #34 — `deb_packages`/`repo_packages` have real Ubuntu 24.04 dependency conflicts (rustdesk needs `libasound2`, which 24.04 renamed; brave-browser conflicts with a package `core` already installs) that need fixing before those tags can join the CI-safe set.

## How to Test

- Open this PR and confirm both the `lint` and `provision` jobs pass.
- Locally: `docker build -t new-computer .` then `docker run --rm new-computer ansible-playbook --tags core,font,zsh,mise ubuntu.yml`.
- Sanity check performed before merging: reintroduced the known `signal-desktop` suite bug (`xenial` → `stable`) in `group_vars/all.yml`, confirmed the job fails with the expected "does not have a Release file" error, then reverted.
