### PR TITLE
chore(#21): bump stale pinned versions

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -77,16 +77,16 @@ project_repos:
 
 deb_packages:
   - name: rustdesk
-    url: "https://github.com/rustdesk/rustdesk/releases/download/1.3.5/rustdesk-1.3.5-x86_64.deb"
-    version: "1.3.5"
+    url: "https://github.com/rustdesk/rustdesk/releases/download/1.4.9/rustdesk-1.4.9-x86_64.deb"
+    version: "1.4.9"
     arch: x86_64
   - name: discord
     url: "https://discord.com/api/download?platform=linux&format=deb"
     version: latest
     arch: amd64
   - name: obsidian
-    url: "https://github.com/obsidianmd/obsidian-releases/releases/download/v1.7.7/obsidian_1.7.7_amd64.deb"
-    version: "1.7.7"
+    url: "https://github.com/obsidianmd/obsidian-releases/releases/download/v1.12.7/obsidian_1.12.7_amd64.deb"
+    version: "1.12.7"
     arch: amd64
 
 # armored: true keys are ASCII-armored and must be dearmored before apt can use them.

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -75,7 +75,7 @@
       amd64: x86_64
       arm64: arm64
   ansible.builtin.get_url:
-    url: "https://github.com/jesseduffield/lazydocker/releases/download/v0.23.3/lazydocker_0.23.3_Linux_{{ lazydocker_arch_map[dpkg_arch.stdout] }}.tar.gz"
+    url: "https://github.com/jesseduffield/lazydocker/releases/download/v0.25.2/lazydocker_0.25.2_Linux_{{ lazydocker_arch_map[dpkg_arch.stdout] }}.tar.gz"
     dest: /tmp/lazydocker.tar.gz
     mode: "0644"
   register: lazydocker_download

--- a/roles/fonts/tasks/main.yml
+++ b/roles/fonts/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Download Fira Code Mono Nerd Font
   ansible.builtin.get_url:
-    url: "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/FiraCode.zip"
+    url: "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraCode.zip"
     dest: /tmp/FiraCode.zip
     mode: "0644"
   tags: font


### PR DESCRIPTION
## Overview

This pull request bumps four stale pinned versions: Lazydocker (v0.23.3 → v0.25.2), RustDesk (1.3.5 → 1.4.9), Obsidian (1.7.7 → 1.12.7), and FiraCode Nerd Font (v3.2.1 → v3.4.0).

## Why

These pins had drifted behind upstream. Left alone, each one gets a little further behind until an upgrade turns into a multi-version jump with more breakage surface than four small bumps would've had.

## Ticket(s)

- Closes #21

## Details

**Version bumps:**

- Updated `roles/docker/tasks/main.yml` to pull Lazydocker v0.25.2.
- Updated `group_vars/all.yml` to pull RustDesk 1.4.9 and Obsidian 1.12.7.
- Updated `roles/fonts/tasks/main.yml` to pull FiraCode Nerd Font v3.4.0.
- Re-verified all four "latest" numbers against GitHub releases at implementation time; they matched the issue's table exactly.

## Known gaps

- Verified the `font` role end-to-end in the `new-computer` Docker image (matches CI's safe-tag set) — installs cleanly at the new version.
- Verified all four download URLs resolve (200) and confirmed Lazydocker v0.25.2 extracts and runs correctly in-container.
- Could not get a clean full `apt install` of the new RustDesk/Obsidian `.deb`s inside the Docker test harness — this hits the same Ubuntu 24.04 dependency-conflict wall already tracked in #34, not something introduced by this version bump (the same failure mode is described there). Deferring that fix to #34 rather than bundling it here.

## How to Test

```
make check && make lint
docker build -t new-computer .
docker run --rm -e TAGS="--tags font" new-computer   # verifies FiraCode bump
```
RustDesk/Obsidian/Lazydocker installs can be verified on a real amd64 Ubuntu 24.04 host via `make run`, where #34's foreign-arch/dependency issue doesn't apply.