### PR TITLE
chore(#22): remove vestigial gitignore and ansible.cfg entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.retry
 .vault_pass
 *.log
 .DS_Store

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,4 +2,3 @@
 interpreter_python = auto_silent
 inventory = inventory.ini
 roles_path = roles
-host_key_checking = False


### PR DESCRIPTION
## Overview

This pull request removes two pieces of dead config: the `*.retry` `.gitignore` entry and the no-op `host_key_checking = False` setting in `ansible.cfg`.

## Why

Neither was actively harmful, but both were unexplained leftovers that make a future reader wonder if they're load-bearing when they're not.

## Ticket(s)

- Closes #22

## Details

**Removed `.gitignore`'s `*.retry` entry:**

- Confirmed `retry_files_enabled` is never set anywhere in the repo, so `ansible-core` never generates `.retry` files regardless of task outcome. The entry was dead weight.

**Removed `ansible.cfg`'s `host_key_checking = False`:**

- The only inventory entry is `localhost` with `ansible_connection=local`, so there's no remote SSH connection for Ansible itself to host-key-check. The `ssh`/`dotfiles`/`personal_projects` roles do their own `git@github.com` SSH connections, which this setting never touched.

## How to Test

- `make check` — syntax check passes
- `make lint` — `ansible-lint` and `yamllint` both pass
- `grep -rn "retry_files_enabled" .` returns nothing, confirming the `.retry` cleanup is safe