### PR TITLE
Run docker role in CI with a privileged container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,21 @@ jobs:
       # Only tags that need no vault password and no SSH access are safe to
       # run in CI. `ssh`, `dotfiles`, and `personal_projects` all require a
       # decrypted deploy key (vault) and/or `git clone` over SSH to
-      # github.com, neither of which this repo hands to CI. `docker` is also
-      # excluded: installing the apt package is fine, but starting the
-      # dockerd service via sysvinit needs a privileged container, which
-      # this job doesn't run with (see #33). `deb_packages` (`install`) and
-      # `repo_packages` (`repo`) are excluded too: several pinned versions
-      # (rustdesk, brave-browser) hit real dependency conflicts on Ubuntu
-      # 24.04, tracked separately by #34 rather than fixed here.
+      # github.com, neither of which this repo hands to CI. `deb_packages`
+      # (`install`) and `repo_packages` (`repo`) are excluded too: several
+      # pinned versions (rustdesk, brave-browser) hit real dependency
+      # conflicts on Ubuntu 24.04, tracked separately by #34 rather than
+      # fixed here.
+      #
+      # `docker` needs `--privileged`: starting the dockerd service via
+      # sysvinit calls `ulimit` in ways plain (non-privileged) containers
+      # reject with "Operation not permitted" (see #33). Security tradeoff:
+      # `--privileged` grants this container the same host access as `-v
+      # /var/run/docker.sock` would, i.e. full control of the runner's
+      # Docker daemon — acceptable here because the container only runs
+      # code from this repo's own checkout, not third-party input, and the
+      # runner is a fresh, disposable GitHub-hosted VM.
       - name: Run playbook inside container
         run: >
-          docker run --rm new-computer
-          ansible-playbook --tags core,font,zsh,mise ubuntu.yml
+          docker run --rm --privileged new-computer
+          ansible-playbook --tags core,font,zsh,mise,docker ubuntu.yml


### PR DESCRIPTION
## Overview

This pull request runs the `docker` tag inside the CI `provision` job using a privileged container, and folds it into the safe tag set that job already exercises.

## Why

Starting dockerd via sysvinit calls `ulimit` in a way a plain container rejects with "Operation not permitted." That's blocked CI from ever exercising the daemon-start half of the `docker` role, which is exactly the kind of apt-repo/GPG-key bug #20 was meant to catch.

## Ticket(s)

- Closes #33

## Details

**CI workflow:**

- Added `--privileged` to the `docker run` invocation in the `provision` job and added `docker` to the `--tags` list, so the role's full apt-repo setup and `service docker start` step both run on every push/PR.
- Rewrote the safe-tag-set comment to document the `--privileged` tradeoff: it grants the container the same host access as mounting the Docker socket would, but that's acceptable since the container only runs this repo's own checkout on a disposable GitHub-hosted runner.

## How to Test

```
docker build -t new-computer .
docker run --rm --privileged new-computer ansible-playbook --tags core,font,zsh,mise,docker ubuntu.yml
```

Confirm the `docker : Start and enable Docker service` task reports `changed` rather than failing.