### PR TITLE
Re-enable install/repo tags in CI provision job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,8 @@ jobs:
       # run in CI. `ssh`, `dotfiles`, and `personal_projects` all require a
       # decrypted deploy key (vault) and/or `git clone` over SSH to
       # github.com, neither of which this repo hands to CI. `deb_packages`
-      # (`install`) and `repo_packages` (`repo`) are excluded too: several
-      # pinned versions (rustdesk, brave-browser) hit real dependency
-      # conflicts on Ubuntu 24.04, tracked separately by #34 rather than
-      # fixed here.
+      # (`install`) and `repo_packages` (`repo`) install cleanly on Ubuntu
+      # 24.04 (verified in #34) and need neither, so they run here too.
       #
       # `docker` needs `--privileged`: starting the dockerd service via
       # sysvinit calls `ulimit` in ways plain (non-privileged) containers
@@ -59,4 +57,4 @@ jobs:
       - name: Run playbook inside container
         run: >
           docker run --rm --privileged new-computer
-          ansible-playbook --tags core,font,zsh,mise,docker ubuntu.yml
+          ansible-playbook --tags core,font,zsh,mise,docker,install,repo ubuntu.yml

--- a/roles/dotfiles/tasks/main.yml
+++ b/roles/dotfiles/tasks/main.yml
@@ -10,7 +10,6 @@
     accept_hostkey: true
     version: master
   tags:
-    - install
     - dotfiles
     - stow
 
@@ -22,6 +21,5 @@
     chdir: "/home/{{ user }}/.dotfiles"
   changed_when: false
   tags:
-    - install
     - dotfiles
     - stow


### PR DESCRIPTION
## Overview

This pull request re-enables the `install` and `repo` tags in CI's provision job and fixes a tag collision that was blocking that from being safe.

## Why

#34 flagged three suspected dependency conflicts (rustdesk/libasound2, brave-browser/liboss4-salsa-asound2, and an unverified code install) as the reason `install` and `repo` were excluded from CI's tag-scoped playbook run.

## Ticket(s)

- Closes #34

## Details

**Tag collision fix:**

- `roles/dotfiles/tasks/main.yml` tagged its two tasks with `install`, `dotfiles`, and `stow` — meaning `--tags install` would also trigger dotfiles' SSH-based git clone, which needs vault/SSH access CI doesn't have. Dropped `install` from those tasks; they keep `dotfiles` and `stow`.

**CI tag set:**

- Verified on a fresh, no-cache, amd64 build of the test image (matching the real GitHub Actions runner arch) that `deb_packages` (rustdesk, discord, obsidian) and `repo_packages` (slack, signal-desktop, brave-browser, code) all install cleanly on Ubuntu 24.04 alongside `core`'s packages. rustdesk's current 1.4.9 pin already lists `libasound2t64 | libasound2` as alternative depends, and brave-browser/code hit no resolver conflict.
- Added `install,repo` to the provision job's `--tags` list in `.github/workflows/ci.yml` and updated the comment accordingly.

## How to Test

```bash
docker build --platform linux/amd64 -t new-computer .
docker run --rm --platform linux/amd64 new-computer ansible-playbook --tags core,font,zsh,mise,install,repo ubuntu.yml
```
Expect `failed=0` in the play recap.