### PR TITLE
Trim cruft from group_vars/all.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Available tags: `ssh`, `font`, `core`, `productivity`, `docker`, `lazydocker`, `
 
 | Category | Details |
 | --- | --- |
-| Shell | ZSH, Oh-My-Zsh, zsh-autosuggestions, zsh-completions, zsh-syntax-highlighting |
+| Shell | ZSH, Oh-My-Zsh (plugins installed by the dotfiles repo's own setup script) |
 | Dev tools | mise (Ruby, Node.js, Python, Go), Docker CE + Lazydocker, GitHub CLI |
 | Fonts | FiraCode Nerd Font v3.2.1 |
 | Dotfiles | Cloned from `github.com/Japenner/.dotfiles`, applied via `.local/bin/dotfiles/setup.zsh` — including git config (identity, includeIf work/personal switching) via its own stow-managed `.gitconfig` |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Available tags: `ssh`, `font`, `core`, `productivity`, `docker`, `lazydocker`, `
 | Fonts | FiraCode Nerd Font v3.2.1 |
 | Dotfiles | Cloned from `github.com/Japenner/.dotfiles`, applied via `.local/bin/dotfiles/setup.zsh` — including git config (identity, includeIf work/personal switching) via its own stow-managed `.gitconfig` |
 | Core packages | build-essential, ripgrep, fzf, tmux, stow, and more |
-| Desktop apps | Brave Browser, Slack, Signal, Discord, Obsidian, RustDesk |
+| Desktop apps | Slack, Signal, Discord, Obsidian, RustDesk |
 | Personal repos | Cloned or updated under `~/repos/personal/` |
 
 ## Development / Testing

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Available tags: `ssh`, `font`, `core`, `productivity`, `docker`, `lazydocker`, `
 | Dev tools | mise (Ruby, Node.js, Python, Go), Docker CE + Lazydocker, GitHub CLI |
 | Fonts | FiraCode Nerd Font v3.2.1 |
 | Dotfiles | Cloned from `github.com/Japenner/.dotfiles`, applied via `.local/bin/dotfiles/setup.zsh` — including git config (identity, includeIf work/personal switching) via its own stow-managed `.gitconfig` |
-| Core packages | build-essential, cmake, clangd, ripgrep, fzf, tmux, picom, stow, and more |
+| Core packages | build-essential, ripgrep, fzf, tmux, stow, and more |
 | Desktop apps | Brave Browser, Slack, Signal, Discord, Obsidian, RustDesk |
 | Personal repos | Cloned or updated under `~/repos/personal/` |
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -37,7 +37,6 @@ apt_packages:
     - software-properties-common
   productivity:
     - tmux
-    - wireshark
     - fzf
     - xclip
     - tldr

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -82,11 +82,6 @@ repo_packages:
     uris: "https://updates.signal.org/desktop/apt"
     suites: xenial
     components: main
-  - name: brave-browser
-    gpg_key_url: "https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg"
-    uris: "https://brave-browser-apt-release.s3.brave.com/"
-    suites: stable
-    components: main
   - name: code
     gpg_key_url: "https://packages.microsoft.com/keys/microsoft.asc"
     uris: "https://packages.microsoft.com/repos/code"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -9,25 +9,15 @@ personal: "/home/{{ user }}/repos/personal"
 apt_packages:
   core:
     - build-essential
-    - cmake
-    - pkg-config
-    - libpthread-stubs0-dev
-    - lua5.1
     - unzip
-    - libtool
-    - libtool-bin
-    - gettext
-    - picom
     - curl
     - htop
     - lsof
     - ccache
-    - ninja-build
     - python3-pip
     - python3-debian
     - dconf-editor
     - moreutils
-    - clangd
     - openssl
     - gnupg
     - libpq-dev

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -58,14 +58,6 @@ mise_global_tools:
   - python@latest
   - go@latest
 
-zsh_plugins:
-  - name: zsh-autosuggestions
-    repo: "https://github.com/zsh-users/zsh-autosuggestions.git"
-  - name: zsh-completions
-    repo: "https://github.com/zsh-users/zsh-completions.git"
-  - name: zsh-syntax-highlighting
-    repo: "https://github.com/zsh-users/zsh-syntax-highlighting.git"
-
 project_repos:
   - anki
   - jacobs_toolbox

--- a/roles/zsh/tasks/main.yml
+++ b/roles/zsh/tasks/main.yml
@@ -37,13 +37,3 @@
     state: absent
   when: zshrc_stat.stat.exists and not zshrc_stat.stat.islnk
   tags: zsh
-
-- name: Clone ZSH plugins
-  become: true
-  become_user: "{{ user }}"
-  ansible.builtin.git:
-    repo: "{{ item.repo }}"
-    dest: "/home/{{ user }}/.oh-my-zsh/custom/plugins/{{ item.name }}"
-    version: master
-  loop: "{{ zsh_plugins }}"
-  tags: zsh


### PR DESCRIPTION
## Overview

This pull request trims unused entries from `group_vars/all.yml`: `wireshark`, the `zsh_plugins` list, eight source-build toolchain packages, `clangd`, `picom`, and `brave-browser`.

## Why

This repo has grown one add-at-a-time for a long stretch and nothing had ever been removed. Each cut below is backed by evidence, not a guess.

## Ticket(s)

- Closes #31

## Details

**Unused apps:**

- Dropped `wireshark` from `apt_packages.productivity` (confirmed unused).
- Dropped `brave-browser` from `repo_packages`. Chrome is the actively-used browser; firefox is the only browser cask tracked in the dotfiles Brewfiles, brave never appears.

**Duplicate work:**

- Dropped `zsh_plugins` and the "Clone ZSH plugins" task in `roles/zsh/tasks/main.yml`. The dotfiles repo's own `zsh/configs/oh-my-zsh.zsh` already clones the same three plugins into the same `$ZSH_CUSTOM/plugins/` path on first interactive shell, so this repo was doing the same clone twice.

**Dead build toolchain:**

- Dropped `cmake`, `ninja-build`, `gettext`, `libtool`, `libtool-bin`, `lua5.1`, `pkg-config`, `libpthread-stubs0-dev`, and `clangd` from `apt_packages.core`. Nothing in this repo builds neovim (or anything else) from source anymore, the only nvim install is a prebuilt PPA package in the test Dockerfile, and LazyVim uses a prebuilt nvim too. `mise`'s Ruby install already uses precompiled binaries, confirmed by the in-container run below.
- Dropped `picom` from `apt_packages.core`. It's i3's compositor and i3 isn't currently in use (dotfiles' `i3/` config hasn't changed since 2023-03-21, unlike the rest of the actively-maintained repo). Easy to re-add if i3 comes back.

**Kept, with evidence:**

- `rustdesk` (1.4.9) and `obsidian` (1.12.7) pins match the current upstream latest release.
- `python3-debian` is a real dependency of `ansible.builtin.deb822_repository`, used by the `repo_packages` role.
- `slack`, `signal-desktop`, `code`, `tldr`, `fzf`, `ripgrep`, `gh`, `tmux`, `stow` all match casks/formulae present in the dotfiles Brewfiles.
- All six `project_repos` entries still exist on GitHub and none are archived.

## How to Test

- `make check` and `make lint` pass.
- `./build-dockers` then `docker run --rm new-computer ansible-playbook --tags core,font,zsh,mise ubuntu.yml` completes with zero failures, confirming the trimmed packages weren't load-bearing for any role.
- `make test` passes.