### PR TITLE
chore(#11): audit .dotfiles for patterns worth porting

### DIFF
--- a/docs/dotfiles-audit.md
+++ b/docs/dotfiles-audit.md
@@ -1,0 +1,55 @@
+# .dotfiles audit — 2026-07-10
+
+Review of `github.com/Japenner/.dotfiles` (the repo this playbook's `dotfiles`
+role clones and stows) for conventions worth porting into this repo. See
+issue #11.
+
+## Findings
+
+### 1. No shellcheck coverage for this repo's shell scripts
+
+`.dotfiles` lints its shell scripts with a checked-in `.shellcheckrc`
+(`disable=SC1071`). This repo has three root-level shell scripts
+(`ansible-run`, `build-dockers`, `clean-env`) that aren't covered by
+`make lint` or CI at all — only the Ansible/YAML side (`ansible-lint`,
+`yamllint`) is linted.
+
+**Verdict:** actionable. Turned into a follow-up issue, labeled `up next`:
+see #41.
+
+### 2. CI and ADRs
+
+`.dotfiles` has no GitHub Actions CI and no ADR log. This repo already has
+both (`.github/workflows/ci.yml`, `docs/adr/`) and is ahead here — nothing to
+port.
+
+### 3. `CONTEXT.md` domain glossary + routing table
+
+`.dotfiles` carries a `CONTEXT.md` with a terms glossary and a
+task-type-to-docs routing table, read by its Claude agent skills. This
+repo's `CLAUDE.md` already contains an equivalent domain glossary and a "Key
+Decisions" section. A separate routing table adds little here: this repo has
+one real workflow shape (add a package/tool to `group_vars/all.yml`, or
+touch a role), not the range of task types (`write feature`, `fix bug`,
+`author a command`, etc.) that justifies `.dotfiles`' table.
+
+**Verdict:** not applicable — already covered by existing `CLAUDE.md`
+content, and the task-type diversity that motivates it in `.dotfiles` isn't
+present here.
+
+### 4. README structure
+
+Both repos organize their README similarly (prerequisites, install/run
+steps, a command/target table, project structure). `.dotfiles` additionally
+has explicit "Contributing" and "License" sections; this repo's README omits
+both, though `CLAUDE.md` already states the "public but not soliciting
+contributions" stance.
+
+**Verdict:** not applicable — low value for a single-maintainer repo where
+the stance is already documented in `CLAUDE.md`.
+
+## Out of scope
+
+No code changes were made under this audit. Idea #1 above was filed as its
+own follow-up issue rather than implemented here, per the parent issue's
+acceptance criteria.


### PR DESCRIPTION
## Overview

This pull request adds a written audit of `github.com/Japenner/.dotfiles`, comparing its structure, tooling, and docs conventions against this repo's own.

## Why

`.dotfiles` and this repo share a maintainer and already interact directly (the `dotfiles` role clones and stows it), so it's worth periodically checking whether patterns proven there are worth raising the bar here too, instead of letting the two repos drift independently.

## Ticket(s)

- Closes #11

## Details

**Audit findings:**

- Reviewed `.dotfiles`' README, `CONTEXT.md`, `.shellcheckrc`, CI setup (none exists), and project layout against this repo's `CLAUDE.md`, `docs/adr/`, and `.github/workflows/ci.yml`.
- Found one concrete, actionable gap: this repo's three root shell scripts (`ansible-run`, `build-dockers`, `clean-env`) have no shellcheck coverage, unlike `.dotfiles`. Filed as its own follow-up issue (#41), labeled `up next`, rather than implemented here.
- The remaining candidates (`.dotfiles`' `CONTEXT.md` routing table, README Contributing/License sections) were assessed as not applicable — already covered by existing `CLAUDE.md` content or low value for this repo's single-maintainer, single-workflow shape.
- `.dotfiles` has no CI and no ADR log, so there was nothing to port on those fronts — this repo is already ahead there.

Findings are written up in `docs/dotfiles-audit.md`. No other code changes were made, per the parent issue's acceptance criteria.

## How to Test

- Read `docs/dotfiles-audit.md`
- Confirm follow-up issue #41 exists and captures the one actionable idea