### PR TITLE
chore(#41): add shellcheck linting for root shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: ansible-lint
         run: ansible-lint
 
+      - name: shellcheck
+        run: shellcheck ansible-run build-dockers clean-env
+
       - name: Syntax check
         run: ansible-playbook --syntax-check ubuntu.yml
 

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,10 @@ run: ## Provision this machine (prompts for vault + sudo passwords)
 check: ## Syntax-check the playbook
 	ansible-playbook --syntax-check $(PLAYBOOK)
 
-lint: ## Run ansible-lint and yamllint (must be installed)
+lint: ## Run ansible-lint, yamllint, and shellcheck (must be installed)
 	ansible-lint
 	yamllint .
+	shellcheck ansible-run build-dockers clean-env
 
 docker: ## Build the Docker test images
 	./build-dockers


### PR DESCRIPTION
## Overview

This pull request wires shellcheck into `make lint` and the CI lint job, covering the three root-level shell scripts (`ansible-run`, `build-dockers`, `clean-env`).

## Why

This repo's lint coverage only checked the Ansible/YAML side (`ansible-lint`, `yamllint`) — the shell scripts had no static analysis at all, so bugs could accumulate silently.

## Ticket(s)

- Closes #41

## Details

**Lint wiring:**

- Added `shellcheck ansible-run build-dockers clean-env` as a step in `make lint`.
- Added a matching `shellcheck` step to the CI `lint` job in `.github/workflows/ci.yml`, right after `ansible-lint`.

**Findings:**

- shellcheck ran clean against all three scripts on the first pass. No fixes or suppressions were needed.

## How to Test

- `make lint` — confirm the `shellcheck` step runs and passes alongside `ansible-lint` and `yamllint`.
- Push to a branch and confirm the CI `lint` job's new `shellcheck` step is green.