### PR TITLE
feat(#40): add google chrome to repo_packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Available tags: `ssh`, `font`, `core`, `productivity`, `docker`, `lazydocker`, `
 | Fonts | FiraCode Nerd Font v3.2.1 |
 | Dotfiles | Cloned from `github.com/Japenner/.dotfiles`, applied via `.local/bin/dotfiles/setup.zsh` — including git config (identity, includeIf work/personal switching) via its own stow-managed `.gitconfig` |
 | Core packages | build-essential, ripgrep, fzf, tmux, stow, and more |
-| Desktop apps | Slack, Signal, Discord, Obsidian, RustDesk |
+| Desktop apps | Slack, Signal, Discord, Obsidian, RustDesk, Google Chrome |
 | Personal repos | Cloned or updated under `~/repos/personal/` |
 
 ## Development / Testing

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -87,3 +87,8 @@ repo_packages:
     uris: "https://packages.microsoft.com/repos/code"
     suites: stable
     components: main
+  - name: google-chrome-stable
+    gpg_key_url: "https://dl.google.com/linux/linux_signing_key.pub"
+    uris: "https://dl.google.com/linux/chrome/deb/"
+    suites: stable
+    components: main


### PR DESCRIPTION
## Overview

This pull request adds a `google-chrome-stable` entry to `repo_packages` in `group_vars/all.yml`, following the same signed-apt-repo pattern already used for `slack`, `signal-desktop`, and `code`.

## Why

Chrome is the browser actually in daily use. `brave-browser` was removed from `repo_packages` (#31) with no replacement, so Chrome needs to be installed some other way. This closes that gap through the mechanism the repo already has for exactly this case.

## Ticket(s)

- Closes #40

## Details

**`repo_packages` data addition:**

- Added a `google-chrome-stable` entry pointed at Google's official signed apt repo (`gpg_key_url`, `uris`, `suites`, `components`), matching the shape of the existing three entries. No role logic changes were needed — `roles/repo_packages/tasks/install.yml` is purely data-driven via `deb822_repository`.
- Confirmed the `armored` field mentioned in the comment above `repo_packages` isn't actually consumed anywhere in `install.yml` — `deb822_repository`'s `signed_by` handles ASCII-armored keys on its own, so the other three entries don't set it either. Left it off here to match.

**README:**

- Added Google Chrome to the "Desktop apps" row in the "What Gets Installed" table.

## How to Test

The `repo_packages` role needs `core`'s `python3-debian` package to run at all, and this repo's test image (`new-computer`) builds arm64 on Apple Silicon by default while Google's Chrome repo only ships amd64 packages — so verify with an amd64 build:

```bash
docker build --platform linux/amd64 --build-arg UBUNTU_VERSION=24.04 -t new-computer .
docker run --rm -e TAGS="--tags core,repo" -it new-computer
```

Confirmed `google-chrome-stable` installs cleanly and `/usr/bin/google-chrome-stable` is present. `make check` and `make lint` both pass.